### PR TITLE
Change working directory when booting Drupal

### DIFF
--- a/src/Codeception/TestDrupalKernel.php
+++ b/src/Codeception/TestDrupalKernel.php
@@ -26,7 +26,10 @@ class TestDrupalKernel extends DrupalKernel
     }
 
     public function bootTestEnvironment($sitePath)
-    {
+    {        
+        // Change the working directory to allow Drupal to find
+        // core/core.services.yml.
+        chdir('web');
         static::bootEnvironment();
         $this->setSitePath($sitePath);
         $this->loadLegacyIncludes();


### PR DESCRIPTION
I was experimenting with deployment identifiers (see Drupal settings.php, a changed deployment identifier forces Drupal to rebuild the DI container) and found that this would cause my Codeception tests to throw this:

    In YamlFileLoader.php line 330:
                                                                              
      [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]  
      The service file "core/core.services.yml" is not valid.                     
                                                                              

    Exception trace:
     Drupal\Core\DependencyInjection\YamlFileLoader->loadFile() at /var/www/projects/[...]/web/core/lib/Drupal/Core/DependencyInjection/YamlFileLoader.php:63
     Drupal\Core\DependencyInjection\YamlFileLoader->load() at /var/www/projects/[...]/web/core/lib/Drupal/Core/DrupalKernel.php:1288
     Drupal\Core\DrupalKernel->compileContainer() at /var/www/projects/[...]/web/core/lib/Drupal/Core/DrupalKernel.php:892
     Drupal\Core\DrupalKernel->initializeContainer() at /var/www/projects/[...]/web/core/lib/Drupal/Core/DrupalKernel.php:468
     Drupal\Core\DrupalKernel->boot() at /var/www/projects/[...]/vendor/dustinleblanc/codeception-drupal-8/src/Codeception/TestDrupalKernel.php:37
     Codeception\TestDrupalKernel->bootTestEnvironment() at /var/www/projects/[...]/vendor/dustinleblanc/codeception-drupal-8/src/Codeception/Module/Drupal8.php:51
     Codeception\Module\Drupal8->__construct() at n/a:n/a
     ReflectionClass->newInstanceArgs() at /var/www/projects/[...]/vendor/codeception/codeception/src/Codeception/Lib/Di.php:84
     Codeception\Lib\Di->instantiate() at /var/www/projects/[...]/vendor/codeception/codeception/src/Codeception/Lib/ModuleContainer.php:92
     Codeception\Lib\ModuleContainer->create() at /var/www/projects/[...]/vendor/codeception/codeception/src/Codeception/SuiteManager.php:67
     Codeception\SuiteManager->__construct() at /var/www/projects/[...]/vendor/codeception/codeception/src/Codeception/Codecept.php:186
     Codeception\Codecept->runSuite() at /var/www/projects/[...]/vendor/codeception/codeception/src/Codeception/Codecept.php:158
     Codeception\Codecept->run() at /var/www/projects/[...]/vendor/codeception/codeception/src/Codeception/Command/Run.php:466
     Codeception\Command\Run->runSuites() at /var/www/projects/[...]/vendor/codeception/codeception/src/Codeception/Command/Run.php:361
     Codeception\Command\Run->execute() at /var/www/projects/[...]/vendor/symfony/console/Command/Command.php:251
     Symfony\Component\Console\Command\Command->run() at /var/www/projects/[...]/vendor/symfony/console/Application.php:946
     Symfony\Component\Console\Application->doRunCommand() at /var/www/projects/[...]/vendor/symfony/console/Application.php:248
     Symfony\Component\Console\Application->doRun() at /var/www/projects/[...]/vendor/symfony/console/Application.php:148
     Symfony\Component\Console\Application->run() at /var/www/projects/[...]/vendor/codeception/codeception/src/Codeception/Application.php:108
     Codeception\Application->run() at /var/www/projects/[...]/vendor/codeception/codeception/codecept:42

The basic problem is that the location of core/core.extensions.yml is hardcoded to the assumption that the cwd is Drupal's root, which is not the case when running codeception tests. I've experimented with a few ways to try and force the correct location, and this seems the one that works.